### PR TITLE
Bugfix/python3.7

### DIFF
--- a/padaos.py
+++ b/padaos.py
@@ -32,7 +32,7 @@ class IntentContainer:
                 (r'\(([^\|)]*)\)', r'{~(\1)~}'),  # (hi) -> {~(hi)~}
 
                 # === Convert to regex literal ===
-                (re.escape, None),  # a b:c -> a\ b\:c
+                (r'(\W)', r'\\\1'),
                 (r' {} '.format, None),  # 'abc' -> ' abc '
 
                 # === Unescape Chars for Convenience ===
@@ -49,9 +49,9 @@ class IntentContainer:
                 (r'\\\|', r'|'),  # \| -> |
 
                 # === Support Special Symbols ===
-                (r'(?<=\s)\\:0(?=\s)', r'\w+'),
-                (r'#', r'\d'),
-                (r'\d', r'\d'),
+                (r'(?<=\s)\\:0(?=\s)', r'\\w+'),
+                (r'#', r'\\d'),
+                (r'\d', r'\\d'),
 
                 # === Space Word Separations ===
                 (r'(?<!\\)(\w)([^\w\s}])', r'\1 \2'),  # a:b -> a :b

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='padaos',
-    version='0.1.6',
+    version='0.1.7',
     description='A rigid, lightweight, dead-simple intent parser',
     url='http://github.com/MatthewScholefield/padaos',
     author='Matthew Scholefield',


### PR DESCRIPTION
Python 3.7 started treating unknown escapes as errors in re.sub, see https://docs.python.org/3/whatsnew/changelog.html **bpo-27030**. This also means that the `re.escape` works in a slightly different way (only escapes special characters in regexps). 

This fixes the few cases where the change seem to matter.