### PR TITLE
Ignore lines producing invalid regexes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='padaos',
-    version='0.1.7',
+    version='0.1.8',
     description='A rigid, lightweight, dead-simple intent parser',
     url='http://github.com/MatthewScholefield/padaos',
     author='Matthew Scholefield',


### PR DESCRIPTION
Now that translations are pouring in from the translation server some incorrect lines are sneaking in causing padaos to throw an exception and halt loading of intents.

This will catch the regex compile error and log the failing line like so:
`"padoas - WARNING - Failed to parse the line "(vad|när) är (mitt|) nästa larm)" for mycroft-alarm.mycroftai:query.next.alarm.intent"`

Padaos will continue to load any other valid lines for the intent.