### PR TITLE
Lock to avoid dict size changed error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='padaos',
-    version='0.1.8',
+    version='0.1.9',
     description='A rigid, lightweight, dead-simple intent parser',
     url='http://github.com/MatthewScholefield/padaos',
     author='Matthew Scholefield',


### PR DESCRIPTION
Adding and removing intents or entities while compiling may cause a RuntimeError, this lock _should_ handle that issue.